### PR TITLE
ci: new workflow to ping daily

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,4 +1,4 @@
-name: Keep Supabase alive
+name: Keep alive
 
 on:
   schedule:
@@ -9,10 +9,4 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      # ponytail: hits the Supabase REST API directly, not /leaderboard —
-      # that page is a client component, so curling it never touches the DB.
-      - run: |
-          curl -fsS --max-time 30 \
-            "${{ secrets.NEXT_PUBLIC_URL }}/rest/v1/stats?select=email&limit=1" \
-            -H "apikey: ${{ secrets.NEXT_PUBLIC_ANONKEY }}" \
-            -H "Authorization: Bearer ${{ secrets.NEXT_PUBLIC_ANONKEY }}"
+      - run: curl -fsS --max-time 30 "${{ vars.SITE_URL }}/leaderboard"

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,18 @@
+name: Keep Supabase alive
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      # ponytail: hits the Supabase REST API directly, not /leaderboard —
+      # that page is a client component, so curling it never touches the DB.
+      - run: |
+          curl -fsS --max-time 30 \
+            "${{ secrets.NEXT_PUBLIC_URL }}/rest/v1/stats?select=email&limit=1" \
+            -H "apikey: ${{ secrets.NEXT_PUBLIC_ANONKEY }}" \
+            -H "Authorization: Bearer ${{ secrets.NEXT_PUBLIC_ANONKEY }}"


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to keep Supabase alive by periodically pinging the Supabase REST API. This helps prevent the Supabase instance from idling or going to sleep.

**New workflow added:**

* [`.github/workflows/keepalive.yml`](diffhunk://#diff-5b612017aa186f5db53b7d1e0e0c902905179baa378516b2391fc91965fd89a7R1-R18): Introduces a scheduled job that uses `curl` to ping the Supabase REST API (`/rest/v1/stats`) once daily and on manual dispatch, ensuring the backend stays active.
This pull request adds a new GitHub Actions workflow to keep the site alive by periodically pinging the `/leaderboard` endpoint.

**Infrastructure / Automation:**

* Added a `.github/workflows/keepalive.yml` workflow that uses a scheduled cron job and manual trigger to send a `curl` request to the `${{ vars.SITE_URL }}/leaderboard` endpoint, helping prevent the site from going idle.